### PR TITLE
feat: modernize contact form + secure it, themed sonner toasts

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,6 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import nodemailer from 'nodemailer';
 import { contactFormSchema } from '@/lib/validation';
 
+// Escape HTML so user input can't inject markup/scripts into the email body.
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+// Strip CR/LF to prevent email header injection via the subject.
+const sanitizeHeader = (value: string) => value.replace(/[\r\n]+/g, ' ').trim();
+
 // Create reusable transporter
 const createTransporter = () => {
   return nodemailer.createTransport({
@@ -27,7 +39,20 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const { name, email, subject, message } = validationResult.data;
+    // Honeypot: if the hidden field is filled, it's a bot. Pretend success.
+    if (validationResult.data.company) {
+      return NextResponse.json({ success: true }, { status: 200 });
+    }
+
+    // Raw (validated) address for the "to" field; header-safe subject line.
+    const recipientEmail = validationResult.data.email;
+    const subjectHeader = sanitizeHeader(validationResult.data.subject);
+
+    // Escape all user-provided values before embedding them in HTML.
+    const name = escapeHtml(validationResult.data.name);
+    const email = escapeHtml(validationResult.data.email);
+    const subject = escapeHtml(validationResult.data.subject);
+    const message = escapeHtml(validationResult.data.message);
 
     // Check environment variables
     if (!process.env.EMAIL_USER || !process.env.EMAIL_PASS) {
@@ -56,7 +81,8 @@ export async function POST(req: NextRequest) {
     const mailToOwner = {
       from: process.env.EMAIL_USER,
       to: process.env.EMAIL_USER,
-      subject: `Portfolio Contact: ${subject}`,
+      replyTo: recipientEmail,
+      subject: `Portfolio Contact: ${subjectHeader}`,
       html: `
         <!DOCTYPE html>
         <html>
@@ -107,7 +133,7 @@ export async function POST(req: NextRequest) {
     // Confirmation email to sender
     const mailToSender = {
       from: process.env.EMAIL_USER,
-      to: email,
+      to: recipientEmail,
       subject: 'Thank you for contacting me!',
       html: `
         <!DOCTYPE html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from '@vercel/analytics/next';
 import { siteConfig } from '@/lib/site';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
+import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -51,11 +52,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <body className={`${inter.className} bg-[#1a1a1a] text-white`}>
         <Navbar />
         <main className="relative">{children}</main>
         <Footer />
+        <Toaster />
         <Analytics />
       </body>
     </html>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -11,9 +11,8 @@ export default function Contact() {
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-3 sm:mb-4">
             Contact Me
           </h2>
-          <div className="w-16 sm:w-20 h-1 bg-blue-600 mx-auto" />
           <p className="text-gray-400 mt-3 sm:mt-4 text-sm sm:text-base">
-            Got what you need? Holla at me
+            Got what you need? Tell me about your project.
           </p>
         </div>
 

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -3,16 +3,19 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { motion } from 'framer-motion';
 import { Send, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
 import { contactFormSchema, type ContactFormData } from '@/lib/validation';
+
+// Always-visible border + darker fill so fields stay distinguished, not just on focus.
+const fieldClass = 'border-gray-700 bg-[#2a2a2a] placeholder:text-gray-500';
 
 export default function ContactForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitStatus, setSubmitStatus] = useState<{
-    type: 'success' | 'error' | null;
-    message: string;
-  }>({ type: null, message: '' });
 
   const {
     register,
@@ -25,14 +28,11 @@ export default function ContactForm() {
 
   const onSubmit = async (data: ContactFormData) => {
     setIsSubmitting(true);
-    setSubmitStatus({ type: null, message: '' });
 
     try {
       const response = await fetch('/api/contact', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
 
@@ -42,18 +42,16 @@ export default function ContactForm() {
         throw new Error(result.error || 'Failed to send message');
       }
 
-      setSubmitStatus({
-        type: 'success',
-        message: "Message sent successfully! I'll get back to you soon.",
+      toast.success('Message sent!', {
+        description: "Thanks for reaching out. I'll get back to you within a day.",
       });
       reset();
     } catch (error) {
-      setSubmitStatus({
-        type: 'error',
-        message:
+      toast.error('Something went wrong!', {
+        description:
           error instanceof Error
             ? error.message
-            : 'Something went wrong. Please try again.',
+            : 'Please try again in a moment.',
       });
     } finally {
       setIsSubmitting(false);
@@ -61,87 +59,98 @@ export default function ContactForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <div className="grid md:grid-cols-2 gap-4">
-        <div>
-          <input
-            {...register('name')}
-            type="text"
-            placeholder="Name"
-            className="w-full bg-[#2a2a2a] border border-gray-700 rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 transition-colors"
-          />
-          {errors.name && (
-            <p className="mt-1 text-sm text-red-400">{errors.name.message}</p>
-          )}
-        </div>
-        <div>
-          <input
-            {...register('email')}
-            type="email"
-            placeholder="Email"
-            className="w-full bg-[#2a2a2a] border border-gray-700 rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 transition-colors"
-          />
-          {errors.email && (
-            <p className="mt-1 text-sm text-red-400">{errors.email.message}</p>
-          )}
-        </div>
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5" noValidate>
+      {/* Honeypot — hidden from users, catches bots */}
+      <div className="absolute left-[-9999px]" aria-hidden="true">
+        <label htmlFor="company">Company</label>
+        <input
+          id="company"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          {...register('company')}
+        />
       </div>
 
-      <div>
-        <input
-          {...register('subject')}
+      <div className="space-y-2">
+        <Label htmlFor="name">Name</Label>
+        <Input
+          id="name"
           type="text"
-          placeholder="Subject"
-          className="w-full bg-[#2a2a2a] border border-gray-700 rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 transition-colors"
+          placeholder="Your name"
+          autoComplete="name"
+          aria-invalid={!!errors.name}
+          className={fieldClass}
+          {...register('name')}
+        />
+        {errors.name && (
+          <p className="text-sm text-red-400">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          type="email"
+          placeholder="you@example.com"
+          autoComplete="email"
+          aria-invalid={!!errors.email}
+          className={fieldClass}
+          {...register('email')}
+        />
+        {errors.email && (
+          <p className="text-sm text-red-400">{errors.email.message}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="subject">Subject</Label>
+        <Input
+          id="subject"
+          type="text"
+          placeholder="What's this about?"
+          aria-invalid={!!errors.subject}
+          className={fieldClass}
+          {...register('subject')}
         />
         {errors.subject && (
-          <p className="mt-1 text-sm text-red-400">{errors.subject.message}</p>
+          <p className="text-sm text-red-400">{errors.subject.message}</p>
         )}
       </div>
 
-      <div>
-        <textarea
+      <div className="space-y-2">
+        <Label htmlFor="message">Message</Label>
+        <Textarea
+          id="message"
+          rows={10}
+          placeholder="Tell me about your project…"
+          aria-invalid={!!errors.message}
+          className={`resize-none ${fieldClass}`}
           {...register('message')}
-          placeholder="Message"
-          rows={5}
-          className="w-full bg-[#2a2a2a] border border-gray-700 rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 transition-colors resize-none"
         />
         {errors.message && (
-          <p className="mt-1 text-sm text-red-400">{errors.message.message}</p>
+          <p className="text-sm text-red-400">{errors.message.message}</p>
         )}
       </div>
 
-      <motion.button
+      <Button
         type="submit"
         disabled={isSubmitting}
-        whileHover={{ scale: 1.02 }}
-        whileTap={{ scale: 0.98 }}
-        className="w-full bg-pink-500/20 hover:bg-pink-500/30 text-pink-300 py-3 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        className="w-full bg-blue-600 text-white hover:bg-blue-700"
       >
         {isSubmitting ? (
           <>
-            <Loader2 size={16} className="animate-spin" />
-            Sending...
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Sending…
           </>
         ) : (
           <>
-            Submit
-            <Send size={16} />
+            Send message
+            <Send className="h-4 w-4" />
           </>
         )}
-      </motion.button>
-
-      {submitStatus.type && (
-        <motion.p
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          className={`text-sm text-center ${
-            submitStatus.type === 'success' ? 'text-green-400' : 'text-red-400'
-          }`}
-        >
-          {submitStatus.message}
-        </motion.p>
-      )}
+      </Button>
     </form>
   );
 }

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -13,7 +13,6 @@ export default function Experience() {
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-3 sm:mb-4 text-white">
             Experience
           </h2>
-          <div className="w-16 sm:w-20 h-1 bg-blue-600 mx-auto" />
           <p className="text-gray-400 mt-3 sm:mt-4 text-sm sm:text-base">
             My working experience
           </p>

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -19,7 +19,6 @@ export default function Services() {
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-3 sm:mb-4">
             What I bring
           </h2>
-          <div className="w-16 sm:w-20 h-1 bg-blue-600 mx-auto" />
           <p className="text-gray-400 mt-3 sm:mt-4 text-sm sm:text-base">
             Services that I offer
           </p>

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -23,7 +23,6 @@ export default function Skills() {
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-3 sm:mb-4">
             Tech Stack
           </h2>
-          <div className="w-16 sm:w-20 h-1 bg-blue-600 mx-auto" />
           <p className="text-gray-400 mt-3 sm:mt-4 text-sm sm:text-base">
             Technologies have been working with recently
           </p>

--- a/components/Workflow.tsx
+++ b/components/Workflow.tsx
@@ -68,7 +68,6 @@ export default function Workflow() {
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-3 sm:mb-4">
             My Workflow
           </h2>
-          <div className="w-16 sm:w-20 h-1 bg-blue-600 mx-auto" />
           <p className="text-gray-400 mt-3 sm:mt-4 text-sm sm:text-base max-w-2xl mx-auto">
             A simple, repeatable process for turning an idea into something real and keeping it working once it&apos;s live.
           </p>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="dark"
+      position="bottom-right"
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4 text-green-500" />,
+        info: <InfoIcon className="size-4 text-blue-500" />,
+        warning: <TriangleAlertIcon className="size-4 text-amber-500" />,
+        error: <OctagonXIcon className="size-4 text-red-500" />,
+        loading: <Loader2Icon className="size-4 animate-spin text-blue-500" />,
+      }}
+      toastOptions={{
+        classNames: {
+          toast: "!bg-[#222] !text-white !border !border-gray-700 !shadow-xl",
+          title: "!text-white !font-semibold",
+          description: "!text-gray-400",
+        },
+      }}
+      style={
+        {
+          "--normal-bg": "#222",
+          "--normal-text": "#ffffff",
+          "--normal-border": "#374151",
+          "--border-radius": "0.75rem",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -2,10 +2,15 @@
 import { z } from 'zod';
 
 export const contactFormSchema = z.object({
-  name: z.string().min(2, 'Name must be at least 2 characters'),
-  email: z.string().email('Invalid email address'),
-  subject: z.string().min(5, 'Subject must be at least 5 characters'),
-  message: z.string().min(10, 'Message must be at least 10 characters'),
+  name: z.string().min(2, 'Name must be at least 2 characters').max(100),
+  email: z.string().email('Invalid email address').max(150),
+  subject: z.string().min(5, 'Subject must be at least 5 characters').max(150),
+  message: z
+    .string()
+    .min(10, 'Message must be at least 10 characters')
+    .max(5000),
+  // Honeypot: real users never see or fill this. Bots do.
+  company: z.string().optional(),
 });
 
 export type ContactFormData = z.infer<typeof contactFormSchema>;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "install": "^0.13.0",
     "lucide-react": "^0.513.0",
     "next": "16.0.8",
+    "next-themes": "^0.4.6",
     "nodemailer": "^7.0.3",
     "radix-ui": "^1.6.2",
     "react": "19.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       next:
         specifier: 16.0.8
         version: 16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       nodemailer:
         specifier: ^7.0.3
         version: 7.0.3
@@ -2473,6 +2476,12 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.0.8:
     resolution: {integrity: sha512-LmcZzG04JuzNXi48s5P+TnJBsTGPJunViNKV/iE4uM6kstjTQsQhvsAv+xF6MJxU2Pr26tl15eVbp0jQnsv6/g==}
@@ -5453,6 +5462,11 @@ snapshots:
   napi-postinstall@0.2.4: {}
 
   natural-compare@1.4.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
 
   next@16.0.8(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:


### PR DESCRIPTION
- Rebuild contact form with shadcn Input/Textarea/Label, outside labels, stacked fields (no grid), and sonner toast notifications
- Security: HTML-escape email inputs, honeypot anti-bot field, strip newlines from subject header, add reply-to
- Add shadcn input/label/textarea/sonner; dark-themed Toaster
- Swap Workflow SVGs for colored lucide icons
- Unify section heading typography across pages